### PR TITLE
Fix argp compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ${{ runner.temp }}\argp-standalone
         run: |
-          cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release .
+          cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-D__GNU_LIBRARY__" .
           make -f ./src/Makefile
 
       - name: Copy argp-standalone


### PR DESCRIPTION
**Describe the bug**
The compilation of argp-standalone for windows builds is no longer working.

**To Reproduce**
https://github.com/GitTor-ISU/GitTor-Cli/actions/runs/18580302081

**Expected behavior**
https://github.com/GitTor-ISU/GitTor-Cli/actions/runs/18577933760

**Screenshots (if applicable)**
<img width="298" height="348" alt="Image" src="https://github.com/user-attachments/assets/6490c4a4-778a-4fe6-9405-7fe0c9b4e36e" />

**Additional context**
