### PR TITLE
25 api connection

### DIFF
--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1,5 +1,7 @@
+#include <glib.h>
 #include <curl/curl.h>
 #include "api/api.h"
+#include "config/config.h"
 
 extern int api_init() {
     CURLcode res = curl_global_init(CURL_GLOBAL_ALL);
@@ -10,18 +12,28 @@ extern void api_cleanup() {
     curl_global_cleanup();
 }
 
-extern int heartbeat(const char* endpoint_url) {
+extern int heartbeat() {
     CURL* curl;
     CURLcode res;
     long response_code = 0;  // NOLINT(runtime/int) - required by curl API
 
+    char* endpoint_url =
+        config_get(CONFIG_SCOPE_LOCAL,
+                   &(config_id_t){.group = "network", .key = "api_url"}, NULL);
+
     if (!endpoint_url) {
-        return -1;  // Invalid URL
+        const char* default_endpoint = "https://gittor.rent/api/";
+        endpoint_url = g_strdup(default_endpoint);
+        g_print("Network API URL not set in config, using default: %s\n",
+                default_endpoint);
     }
 
     curl = curl_easy_init();
-    if (!curl)
+    if (!curl) {
+        if (endpoint_url)
+            free(endpoint_url);
         return -1;  // Initialization failed
+    }
 
     curl_easy_setopt(curl, CURLOPT_URL, endpoint_url);
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5L);  // 5 seconds timeout
@@ -32,9 +44,13 @@ extern int heartbeat(const char* endpoint_url) {
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
         curl_easy_cleanup(curl);
 
+        if (endpoint_url)
+            free(endpoint_url);
         return (response_code >= 200 && response_code < 300) ? 0 : -1;
     }
 
     curl_easy_cleanup(curl);
+    if (endpoint_url)
+        free(endpoint_url);
     return -1;  // Network/CURL error
 }

--- a/src/api/api.h
+++ b/src/api/api.h
@@ -14,11 +14,11 @@ extern int api_init();
 extern void api_cleanup();
 
 /**
- * @brief Sends a heartbeat signal to the specified endpoint.
+ * @brief Sends a heartbeat signal to the endpoint specified in the config at
+ * network.api_url, or defaults to "https://gittor.rent/api/" if not set.
  *
- * @param endpoint_url The URL of the endpoint to send the heartbeat to
  * @return int 0 on success, non-zero on failure
  */
-extern int heartbeat(const char* endpoint_url);
+extern int heartbeat();
 
 #endif  // API_API_H_

--- a/test/api_test.c
+++ b/test/api_test.c
@@ -1,31 +1,92 @@
+#include <glib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 #include "api/api.h"
+#include "cmd/cmd.h"
+#include "config/config.h"
 #include "unity/unity.h"
+#include "utils/utils.h"
 
-static void shouldPass_whenHeartbeatToValidEndpoint() {
+static char* TEST_DIR = NULL;
+static char TEST_GLOBAL_CONFIG_PATH[PATH_MAX + 27];
+static char TEST_LOCAL_CONFIG_PATH[PATH_MAX + 27];
+
+static char* original_home = NULL;
+static char* original_cwd = NULL;
+
+void setUp() {
+    // Save original environment
+    original_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
+    original_cwd = getcwd(NULL, 0);
+
+    // Create test directory
+    TEST_DIR = tempdir_init();
+    snprintf(TEST_GLOBAL_CONFIG_PATH, sizeof(TEST_GLOBAL_CONFIG_PATH),
+             "%s/.test_global_gittorconfig", TEST_DIR);
+    snprintf(TEST_LOCAL_CONFIG_PATH, sizeof(TEST_LOCAL_CONFIG_PATH),
+             "%s/.test_local_gittorconfig", TEST_DIR);
+
+    // Set HOME to controlled location for global config
+    setenv("HOME", TEST_DIR, 1);
+    chdir(TEST_DIR);
+}
+
+void tearDown() {
+    // Remove test config files
+    unlink(TEST_GLOBAL_CONFIG_PATH);
+    unlink(TEST_LOCAL_CONFIG_PATH);
+
+    // Restore original HOME
+    if (original_cwd) {
+        chdir(original_cwd);
+        free(original_cwd);
+        original_cwd = NULL;
+    }
+    if (original_home) {
+        setenv("HOME", original_home, 1);
+        free(original_home);
+        original_home = NULL;
+    }
+
+    // Remove test directory
+    tempdir_destroy(TEST_DIR);
+}
+
+static void shouldPass_whenNetworkAPIUrlIsSet() {
     // GIVEN: A valid endpoint URL
-    const char* endpoint_url = "https://gittor.rent/api/";
+    char* argv[] = {"gittor",
+                    "config",
+                    "--local",
+                    "network.api_url",
+                    "https://gittor.rent/api/",
+                    NULL};
+    cmd_parse(5, argv);
 
     // WHEN: Call heartbeat
-    int err = heartbeat(endpoint_url);
+    int err = heartbeat();
 
     // THEN: Should return 0 error
     TEST_ASSERT_EQUAL(0, err);
 }
 
-static void shouldFail_whenHeartbeatToInvalidEndpoint() {
-    // GIVEN: An invalid endpoint URL
-    const char* endpoint_url = "http://invalid.endpoint.local/api/";
-
+static void shouldPass_whenNetworkAPIUrlNotSet() {
     // WHEN: Call heartbeat
-    int err = heartbeat(endpoint_url);
+    int err = heartbeat();
 
-    // THEN: Should return non-zero error
-    TEST_ASSERT_NOT_EQUAL(0, err);
+    // THEN: Should return 0 error
+    TEST_ASSERT_EQUAL(0, err);
 }
 
 int main() {
     UNITY_BEGIN();
-    RUN_TEST(shouldPass_whenHeartbeatToValidEndpoint);
-    RUN_TEST(shouldFail_whenHeartbeatToInvalidEndpoint);
+
+    setUp();
+    RUN_TEST(shouldPass_whenNetworkAPIUrlIsSet);
+    tearDown();
+
+    RUN_TEST(shouldPass_whenNetworkAPIUrlNotSet);
+
     return UNITY_END();
 }


### PR DESCRIPTION
**High-level Overview**
We need to have a collection of functions that will allow the CLI to communicate to the API.

**Description**
Create a new src/api/ folder to store all these functions and implement a heartbeat function that takes in the root url to the api (i.e. https://79.127.136.196:38791/api/), calls the heartbeat endpoint (which actually happens to be the root url), and returns a boolean result of whether the heartbeat was successful and responded true.

**Tests Needed**
Since we don't really have an api running, we won't be able to test these functions. Although, in the future we will want to test things that do call the api, so put this in a mock.

**Acceptance Criteria**
The heartbeat endpoint can be called from a function within the CLI which returns the result of the call and the function is inside a mock.

**Dev Notes**
This one was very simple. Since we have an api running now, there are a couple of test cases. I made an initialization and cleanup function because `curl_easy_init()` is not thread-safe, but I didn't bother calling them in testing because they are trivial and it will call the function itself anyways. Also, there was a lint rule that had to be suppressed because the libcurl api docs require the use of the type `long`, which the linter does not like (fairly).