### PR TITLE
37 torrent api

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          xcopy "${{ runner.temp }}\vcpkg\installed\x64-mingw-static\include" ".\inc" /E /I /Y
+          xcopy "${{ runner.temp }}\vcpkg\installed\x64-windows\include" ".\inc" /E /I /Y
           xcopy "${{ runner.temp }}\libtorrent\include" ".\inc\libtorrent" /E /I /Y
           Copy-Item "${{ runner.temp }}\libtorrent\build\libtorrent-rasterbar.dll.a" ".\lib\libtorrent-rasterbar.dll.a"
           Copy-Item "${{ runner.temp }}\libtorrent\build\libtorrent-rasterbar.dll" ".\lib\libtorrent-rasterbar.dll"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
-          xcopy "${{ runner.temp }}\vcpkg\installed\x64-windows\include" ".\inc" /E /I /Y
+          xcopy "${{ runner.temp }}\vcpkg\installed\x64-mingw-static\include" ".\inc" /E /I /Y
           xcopy "${{ runner.temp }}\libtorrent\include" ".\inc\libtorrent" /E /I /Y
           Copy-Item "${{ runner.temp }}\libtorrent\build\libtorrent-rasterbar.dll.a" ".\lib\libtorrent-rasterbar.dll.a"
           Copy-Item "${{ runner.temp }}\libtorrent\build\libtorrent-rasterbar.dll" ".\lib\libtorrent-rasterbar.dll"

--- a/src/api/internal.c
+++ b/src/api/internal.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <glib.h>
 #include <stdio.h>
 #include <string.h>
@@ -50,8 +51,6 @@ extern char* api_get_base_url() {
     // If not set, use the default
     if (!endpoint_url) {
         endpoint_url = g_strdup(DEFAULT_API_URL);
-        g_print("Network API URL not set in config, using default: %s\n",
-                DEFAULT_API_URL);
     }
 
     // Remove trailing slashes
@@ -63,22 +62,40 @@ extern char* api_get_base_url() {
     return endpoint_url;
 }
 
-extern char* api_get_token() {
-    return config_get(CONFIG_SCOPE_LOCAL,
-                      &(config_id_t){.group = "auth", .key = "access_token"},
-                      NULL);
-}
+extern api_result_e api_auth_headers(struct curl_slist** headers) {
+    api_result_e result = API_OK;
 
-extern struct curl_slist* api_auth_headers(struct curl_slist* headers) {
-    char* token = api_get_token();
-    if (token && token[0]) {
-        char* hdr = g_strdup_printf("Authorization: Bearer %s", token);
-        headers = curl_slist_append(headers, hdr);
-        g_free(hdr);
+    char* token = config_get(
+        CONFIG_SCOPE_LOCAL,
+        &(config_id_t){.group = "auth", .key = "access_token"}, NULL);
+
+    char* expires =
+        config_get(CONFIG_SCOPE_LOCAL,
+                   &(config_id_t){.group = "auth", .key = "expires"}, NULL);
+
+    time_t exp = 0;
+    time_t now = time(NULL);
+
+    if (!token || !token[0]) {
+        g_printerr("Not authenticated. Please run 'gittor login' to login.\n");
+        result = API_AUTH_MISSING;
+    } else if (parse_expiry_epoch(expires, &exp)) {
+        g_printerr("Invalid token expiry in config. Please log in again.\n");
+        result = API_AUTH_INVALID_FORMAT;
+    } else if (exp <= now) {
+        g_printerr(
+            "Session expired. Please run 'gittor login' to authenticate "
+            "again.\n");
+        result = API_AUTH_EXPIRED;
+    } else {
+        char* header = g_strdup_printf("Authorization: Bearer %s", token);
+        *headers = curl_slist_append(*headers, header);
+        g_free(header);
     }
 
     g_free(token);
-    return headers;
+    g_free(expires);
+    return result;
 }
 
 extern CURL* api_curl_handle_new() {
@@ -144,16 +161,16 @@ extern api_result_e api_check_response(CURL* curl, CURLcode res) {
 }
 
 extern int parse_expiry_epoch(const char* expires, time_t* epoch_out) {
-    if (!expires || expires[0] == '\0' || !epoch_out) {
+    if (!expires || !expires[0] || !epoch_out) {
         return EINVAL;
     }
 
-    errno = 0;
-    char* endptr = NULL;
-    gint64 value = g_ascii_strtoll(expires, &endptr, 10);
-    if (errno != 0 || endptr == expires || *endptr != '\0' || value < 0)
+    GDateTime* dt = g_date_time_new_from_iso8601(expires, NULL);
+    if (!dt)
         return EINVAL;
 
-    *epoch_out = (time_t)value;
+    *epoch_out = (time_t)g_date_time_to_unix(dt);
+    g_date_time_unref(dt);
+
     return 0;
 }

--- a/src/api/internal.h
+++ b/src/api/internal.h
@@ -14,7 +14,10 @@ typedef enum {
     API_NOT_FOUND,
     API_FORBIDDEN,
     API_SERVER_ERR,
-    API_CURL_ERR
+    API_CURL_ERR,
+    API_AUTH_MISSING,
+    API_AUTH_INVALID_FORMAT,
+    API_AUTH_EXPIRED,
 } api_result_e;
 
 /**
@@ -53,21 +56,15 @@ extern size_t write_file_cb(void* ptr, size_t size, size_t nmemb, void* stream);
 extern char* api_get_base_url();
 
 /**
- * @brief Get the auth token from config, if set. Caller must free the returned
- * string.
+ * @brief Add authentication headers to a curl_slist. Caller should pass a
+ * pointer to their existing headers list, and this function will append auth
+ * headers if available.
  *
- * @return char* The auth token or NULL if not configured
+ * @param headers Pointer to the existing curl_slist* of headers (can be NULL)
+ * @return api_result_e API_OK if headers were added successfully, or an
+ * appropriate error code if authentication info is missing/invalid/expired
  */
-extern char* api_get_token();
-
-/**
- * @brief Append the Authorization header to a curl_slist if a token is
- * configured.
- *
- * @param headers Existing curl_slist of headers, or NULL to start a new list
- * @return struct curl_slist* Updated header list
- */
-extern struct curl_slist* api_auth_headers(struct curl_slist* headers);
+extern api_result_e api_auth_headers(struct curl_slist** headers);
 
 /**
  * @brief Create a new CURL handle with standard project settings (timeouts,
@@ -97,9 +94,10 @@ extern int api_build_url(char* out, size_t out_size, const char* path_fmt, ...);
 extern api_result_e api_check_response(CURL* curl, CURLcode res);
 
 /**
- * @brief Parse an expiry time from a string epoch format to time_t.
+ * @brief Parse an expiry time string (expected to be in ISO 8601 format) into a
+ * time_t epoch value.
  *
- * @param expires The expiry time as a string (should be a numeric epoch)
+ * @param expires The expiry time string to parse
  * @param epoch_out Output parameter for the parsed time_t value
  * @return int 0 on success, non-zero on failure
  */

--- a/src/api/internal.h
+++ b/src/api/internal.h
@@ -48,7 +48,7 @@ extern size_t write_file_cb(void* ptr, size_t size, size_t nmemb, void* stream);
  * @brief Get the base API URL from config or default. Caller must free the
  * returned string.
  *
- * @return char* The base API URL (eg. "https://gittor.rent/api/")
+ * @return char* The base API URL (e.g. "https://gittor.rent/api/")
  */
 extern char* api_get_base_url();
 
@@ -56,7 +56,7 @@ extern char* api_get_base_url();
  * @brief Get the auth token from config, if set. Caller must free the returned
  * string.
  *
- * @return char* The auth token or Null if not configured
+ * @return char* The auth token or NULL if not configured
  */
 extern char* api_get_token();
 
@@ -82,7 +82,7 @@ extern CURL* api_curl_handle_new();
  *
  * @param out Output buffer
  * @param out_size Size of the output buffer
- * @param path_fmt Format string for the API path (eg. "torrents/%ld")
+ * @param path_fmt Format string for the API path (e.g. "torrents/%ld")
  * @return int 0 on success, non-zero if the URL was truncated
  */
 extern int api_build_url(char* out, size_t out_size, const char* path_fmt, ...);

--- a/src/api/torrents.c
+++ b/src/api/torrents.c
@@ -1,6 +1,7 @@
 #include <glib.h>
 #include <inttypes.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <json-glib/json-glib.h>
 #include "api/internal.h"
 #include "api/torrents.h"
@@ -58,6 +59,36 @@ torrent_dto_t* parse_torrent_json(const char* json_str) {
     return dto;
 }
 
+char* build_update_json(const torrent_update_t* update) {
+    JsonBuilder* builder = json_builder_new();
+    json_builder_begin_object(builder);
+
+    if (update->name) {
+        json_builder_set_member_name(builder, "name");
+        json_builder_add_string_value(builder, update->name);
+    }
+
+    if (update->description) {
+        json_builder_set_member_name(builder, "description");
+        json_builder_add_string_value(builder, update->description);
+    }
+
+    json_builder_end_object(builder);
+
+    JsonGenerator* generator = json_generator_new();
+    JsonNode* root = json_builder_get_root(builder);
+    json_generator_set_root(generator, root);
+    json_node_free(root);
+
+    gsize len = 0;
+    char* json_str = json_generator_to_data(generator, &len);
+
+    g_object_unref(generator);
+    g_object_unref(builder);
+
+    return json_str;
+}
+
 extern void torrent_dto_free(torrent_dto_t* dto) {
     if (!dto)
         return;
@@ -80,7 +111,7 @@ extern torrent_dto_t* api_get_torrent(int64_t torrent_id,
         return NULL;
     }
 
-    // Build the URL
+    // Build the URL: /torrents/{id}
     char url[1024];
     if (api_build_url(url, sizeof(url), "/torrents/%" PRId64, torrent_id)) {
         curl_easy_cleanup(curl);
@@ -125,4 +156,159 @@ extern torrent_dto_t* api_get_torrent(int64_t torrent_id,
         *result = API_SERVER_ERR;
 
     return dto;
+}
+
+extern torrent_dto_t* api_update_torrent(int64_t torrent_id,
+                                         const torrent_update_t* update,
+                                         api_result_e* result) {
+    if (!update) {
+        if (result)
+            *result = API_CURL_ERR;
+
+        return NULL;
+    }
+
+    CURL* curl = api_curl_handle_new();
+    if (!curl) {
+        if (result)
+            *result = API_CURL_ERR;
+
+        return NULL;
+    }
+
+    // Build the URL: /torrents/{id}
+    char url[1024];
+    if (api_build_url(url, sizeof(url), "/torrents/%" PRId64, torrent_id)) {
+        curl_easy_cleanup(curl);
+        if (result)
+            *result = API_SERVER_ERR;
+
+        return NULL;
+    }
+
+    // Serialize the update struct to JSON
+    char* json_str = build_update_json(update);
+    if (!json_str) {
+        curl_easy_cleanup(curl);
+        if (result)
+            *result = API_CURL_ERR;
+
+        return NULL;
+    }
+
+    // Build multipart form data with the JSON string
+    curl_mime* mime = curl_mime_init(curl);
+    curl_mimepart* part = curl_mime_addpart(mime);
+    curl_mime_name(part, "metadata");
+    curl_mime_data(part, json_str, CURL_ZERO_TERMINATED);
+    curl_mime_type(part, "application/json");
+
+    // Set up headers
+    struct curl_slist* headers = NULL;
+    headers = curl_slist_append(headers, "Accept: application/json");
+    headers = api_auth_headers(headers);
+
+    response_buf_t response = response_buf_init();
+
+    // Configure curl for PUT with multipart body
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
+    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+
+    CURLcode res = curl_easy_perform(curl);
+    api_result_e check = api_check_response(curl, res);
+
+    curl_mime_free(mime);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    g_free(json_str);
+
+    if (result)
+        *result = check;
+
+    if (check != API_OK) {
+        g_free(response.data);
+        return NULL;
+    }
+
+    // Parse the returned TorrentDto JSON
+    torrent_dto_t* dto = parse_torrent_json(response.data);
+    g_free(response.data);
+
+    if (!dto && result)
+        *result = API_SERVER_ERR;
+
+    return dto;
+}
+
+extern int api_get_torrent_file(int64_t torrent_id,
+                                const char* output_path,
+                                api_result_e* result) {
+    if (!output_path) {
+        if (result)
+            *result = API_CURL_ERR;
+
+        return -1;
+    }
+
+    CURL* curl = api_curl_handle_new();
+    if (!curl) {
+        if (result)
+            *result = API_CURL_ERR;
+
+        return -1;
+    }
+
+    // Build the URL: /torrents/{id}/file
+    char url[1024];
+    if (api_build_url(url, sizeof(url), "/torrents/%" PRId64 "/file",
+                      torrent_id)) {
+        curl_easy_cleanup(curl);
+        if (result)
+            *result = API_SERVER_ERR;
+
+        return -1;
+    }
+
+    // Open the output file for writing binary
+    FILE* fp = fopen(output_path, "wb");
+    if (!fp) {
+        curl_easy_cleanup(curl);
+        if (result)
+            *result = API_CURL_ERR;
+
+        return -1;
+    }
+
+    // Set up headers
+    struct curl_slist* headers = NULL;
+    headers = curl_slist_append(headers, "Accept: application/x-bittorrent");
+    headers = api_auth_headers(headers);
+
+    // Set curl options and perform request
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_file_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
+
+    CURLcode res = curl_easy_perform(curl);
+    api_result_e check = api_check_response(curl, res);
+
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    fclose(fp);
+
+    if (result)
+        *result = check;
+
+    // Remove partial file on error
+    if (check != API_OK) {
+        remove(output_path);
+        return -1;
+    }
+
+    return 0;
 }

--- a/src/api/torrents.c
+++ b/src/api/torrents.c
@@ -1,0 +1,128 @@
+#include <glib.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <json-glib/json-glib.h>
+#include "api/internal.h"
+#include "api/torrents.h"
+
+torrent_dto_t* parse_torrent_json(const char* json_str) {
+    JsonParser* parser = json_parser_new();
+
+    // Load JSON data into parser
+    if (!json_parser_load_from_data(parser, json_str, -1, NULL)) {
+        g_object_unref(parser);
+        return NULL;
+    }
+
+    // Get the root to make sure it's an object
+    JsonNode* root_node = json_parser_get_root(parser);
+    if (!root_node || !JSON_NODE_HOLDS_OBJECT(root_node)) {
+        g_object_unref(parser);
+        return NULL;
+    }
+
+    // Parse JSON object into torrent_dto_t
+    JsonObject* root_obj = json_node_get_object(root_node);
+    torrent_dto_t* dto = g_malloc0(sizeof(torrent_dto_t));
+
+    if (json_object_has_member(root_obj, "id"))
+        dto->id = json_object_get_int_member(root_obj, "id");
+
+    if (json_object_has_member(root_obj, "name"))
+        dto->name = g_strdup(json_object_get_string_member(root_obj, "name"));
+
+    if (json_object_has_member(root_obj, "description"))
+        dto->description =
+            g_strdup(json_object_get_string_member(root_obj, "description"));
+
+    if (json_object_has_member(root_obj, "fileSize"))
+        dto->file_size = json_object_get_int_member(root_obj, "fileSize");
+
+    if (json_object_has_member(root_obj, "uploaderId"))
+        dto->uploader_id =
+            (int32_t)json_object_get_int_member(root_obj, "uploaderId");
+
+    if (json_object_has_member(root_obj, "uploaderUsername"))
+        dto->uploader_username = g_strdup(
+            json_object_get_string_member(root_obj, "uploaderUsername"));
+
+    if (json_object_has_member(root_obj, "createdAt"))
+        dto->created_at =
+            g_strdup(json_object_get_string_member(root_obj, "createdAt"));
+
+    if (json_object_has_member(root_obj, "updatedAt"))
+        dto->updated_at =
+            g_strdup(json_object_get_string_member(root_obj, "updatedAt"));
+
+    g_object_unref(parser);
+    return dto;
+}
+
+extern void torrent_dto_free(torrent_dto_t* dto) {
+    if (!dto)
+        return;
+
+    g_free(dto->name);
+    g_free(dto->description);
+    g_free(dto->uploader_username);
+    g_free(dto->created_at);
+    g_free(dto->updated_at);
+    g_free(dto);
+}
+
+extern torrent_dto_t* api_get_torrent(int64_t torrent_id,
+                                      api_result_e* result) {
+    CURL* curl = api_curl_handle_new();
+    if (!curl) {
+        if (result)
+            *result = API_CURL_ERR;
+
+        return NULL;
+    }
+
+    // Build the URL
+    char url[1024];
+    if (api_build_url(url, sizeof(url), "/torrents/%" PRId64, torrent_id)) {
+        curl_easy_cleanup(curl);
+        if (result)
+            *result = API_SERVER_ERR;
+
+        return NULL;
+    }
+
+    // Set up headers and response buffer
+    struct curl_slist* headers = NULL;
+    headers = curl_slist_append(headers, "Accept: application/json");
+    headers = api_auth_headers(headers);
+
+    response_buf_t response = response_buf_init();
+
+    // Set curl options and perform request
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+
+    CURLcode res = curl_easy_perform(curl);
+    api_result_e check = api_check_response(curl, res);
+
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
+    if (result)
+        *result = check;
+
+    if (check != API_OK) {
+        g_free(response.data);
+        return NULL;
+    }
+
+    // Parse JSON response into DTO
+    torrent_dto_t* dto = parse_torrent_json(response.data);
+    g_free(response.data);
+
+    if (!dto && result)
+        *result = API_SERVER_ERR;
+
+    return dto;
+}

--- a/src/api/torrents.c
+++ b/src/api/torrents.c
@@ -89,6 +89,34 @@ char* build_update_json(const torrent_update_t* update) {
     return json_str;
 }
 
+char* build_upload_json(const torrent_upload_t* upload) {
+    JsonBuilder* builder = json_builder_new();
+    json_builder_begin_object(builder);
+
+    json_builder_set_member_name(builder, "name");
+    json_builder_add_string_value(builder, upload->name);
+
+    if (upload->description) {
+        json_builder_set_member_name(builder, "description");
+        json_builder_add_string_value(builder, upload->description);
+    }
+
+    json_builder_end_object(builder);
+
+    JsonGenerator* generator = json_generator_new();
+    JsonNode* root = json_builder_get_root(builder);
+    json_generator_set_root(generator, root);
+    json_node_free(root);
+
+    gsize len = 0;
+    char* json_str = json_generator_to_data(generator, &len);
+
+    g_object_unref(generator);
+    g_object_unref(builder);
+
+    return json_str;
+}
+
 extern void torrent_dto_free(torrent_dto_t* dto) {
     if (!dto)
         return;
@@ -203,14 +231,14 @@ extern torrent_dto_t* api_update_torrent(int64_t torrent_id,
     curl_mime_data(part, json_str, CURL_ZERO_TERMINATED);
     curl_mime_type(part, "application/json");
 
-    // Set up headers
+    // Set up headers and response buffer
     struct curl_slist* headers = NULL;
     headers = curl_slist_append(headers, "Accept: application/json");
     headers = api_auth_headers(headers);
 
     response_buf_t response = response_buf_init();
 
-    // Configure curl for PUT with multipart body
+    // Configure curl for PUT with multipart body and perform request
     curl_easy_setopt(curl, CURLOPT_URL, url);
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
@@ -311,4 +339,153 @@ extern int api_get_torrent_file(int64_t torrent_id,
     }
 
     return 0;
+}
+
+extern int api_update_torrent_file(int64_t torrent_id,
+                                   const char* file_path,
+                                   api_result_e* result) {
+    if (!file_path) {
+        if (result)
+            *result = API_CURL_ERR;
+
+        return -1;
+    }
+
+    CURL* curl = api_curl_handle_new();
+    if (!curl) {
+        if (result)
+            *result = API_CURL_ERR;
+
+        return -1;
+    }
+
+    // Build the URL: /torrents/{id}/file
+    char url[1024];
+    if (api_build_url(url, sizeof(url), "/torrents/%" PRId64 "/file",
+                      torrent_id)) {
+        curl_easy_cleanup(curl);
+        if (result)
+            *result = API_SERVER_ERR;
+
+        return -1;
+    }
+
+    // Build multipart form data with the .torrent file
+    curl_mime* mime = curl_mime_init(curl);
+    curl_mimepart* part = curl_mime_addpart(mime);
+    curl_mime_name(part, "file");
+    curl_mime_filedata(part, file_path);
+    curl_mime_type(part, "application/x-bittorrent");
+
+    // Set up headers
+    struct curl_slist* headers = NULL;
+    headers = api_auth_headers(headers);
+
+    // Configure curl for PUT with multipart body and perform request
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
+    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
+
+    CURLcode res = curl_easy_perform(curl);
+    api_result_e check = api_check_response(curl, res);
+
+    curl_mime_free(mime);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
+    if (result)
+        *result = check;
+
+    return (check == API_OK) ? 0 : -1;
+}
+
+extern torrent_dto_t* api_upload_torrent(const torrent_upload_t* upload,
+                                         api_result_e* result) {
+    if (!upload || !upload->name || !upload->file_path) {
+        if (result)
+            *result = API_CURL_ERR;
+
+        return NULL;
+    }
+
+    CURL* curl = api_curl_handle_new();
+    if (!curl) {
+        if (result)
+            *result = API_CURL_ERR;
+
+        return NULL;
+    }
+
+    // Build the URL: /torrents
+    char url[1024];
+    if (api_build_url(url, sizeof(url), "/torrents")) {
+        curl_easy_cleanup(curl);
+        if (result)
+            *result = API_SERVER_ERR;
+
+        return NULL;
+    }
+
+    // Serialize the metadata to JSON
+    char* json_str = build_upload_json(upload);
+    if (!json_str) {
+        curl_easy_cleanup(curl);
+        if (result)
+            *result = API_CURL_ERR;
+
+        return NULL;
+    }
+
+    // Build multipart form data with the JSON string and .torrent file
+    curl_mime* mime = curl_mime_init(curl);
+
+    curl_mimepart* meta_part = curl_mime_addpart(mime);
+    curl_mime_name(meta_part, "metadata");
+    curl_mime_data(meta_part, json_str, CURL_ZERO_TERMINATED);
+    curl_mime_type(meta_part, "application/json");
+
+    curl_mimepart* file_part = curl_mime_addpart(mime);
+    curl_mime_name(file_part, "file");
+    curl_mime_filedata(file_part, upload->file_path);
+    curl_mime_type(file_part, "application/x-bittorrent");
+
+    // Set up headers and response buffer
+    struct curl_slist* headers = NULL;
+    headers = curl_slist_append(headers, "Accept: application/json");
+    headers = api_auth_headers(headers);
+
+    response_buf_t response = response_buf_init();
+
+    // Configure curl for POST with multipart body and perform request
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+
+    CURLcode res = curl_easy_perform(curl);
+    api_result_e check = api_check_response(curl, res);
+
+    curl_mime_free(mime);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    g_free(json_str);
+
+    if (result)
+        *result = check;
+
+    if (check != API_OK) {
+        g_free(response.data);
+        return NULL;
+    }
+
+    // Parse the returned TorrentDto JSON
+    torrent_dto_t* dto = parse_torrent_json(response.data);
+    g_free(response.data);
+
+    if (!dto && result)
+        *result = API_SERVER_ERR;
+
+    return dto;
 }

--- a/src/api/torrents.c
+++ b/src/api/torrents.c
@@ -152,7 +152,15 @@ extern torrent_dto_t* api_get_torrent(int64_t torrent_id,
     // Set up headers and response buffer
     struct curl_slist* headers = NULL;
     headers = curl_slist_append(headers, "Accept: application/json");
-    headers = api_auth_headers(headers);
+    api_result_e auth_result = api_auth_headers(&headers);
+    if (auth_result != API_OK) {
+        curl_slist_free_all(headers);
+        curl_easy_cleanup(curl);
+        if (result)
+            *result = auth_result;
+
+        return NULL;
+    }
 
     response_buf_t response = response_buf_init();
 
@@ -234,7 +242,16 @@ extern torrent_dto_t* api_update_torrent(int64_t torrent_id,
     // Set up headers and response buffer
     struct curl_slist* headers = NULL;
     headers = curl_slist_append(headers, "Accept: application/json");
-    headers = api_auth_headers(headers);
+    api_result_e auth_result = api_auth_headers(&headers);
+    if (auth_result != API_OK) {
+        curl_mime_free(mime);
+        curl_slist_free_all(headers);
+        curl_easy_cleanup(curl);
+        if (result)
+            *result = auth_result;
+
+        return NULL;
+    }
 
     response_buf_t response = response_buf_init();
 
@@ -314,7 +331,16 @@ extern int api_get_torrent_file(int64_t torrent_id,
     // Set up headers
     struct curl_slist* headers = NULL;
     headers = curl_slist_append(headers, "Accept: application/x-bittorrent");
-    headers = api_auth_headers(headers);
+    api_result_e auth_result = api_auth_headers(&headers);
+    if (auth_result != API_OK) {
+        curl_slist_free_all(headers);
+        curl_easy_cleanup(curl);
+        fclose(fp);
+        if (result)
+            *result = auth_result;
+
+        return -1;
+    }
 
     // Set curl options and perform request
     curl_easy_setopt(curl, CURLOPT_URL, url);
@@ -379,7 +405,16 @@ extern int api_update_torrent_file(int64_t torrent_id,
 
     // Set up headers
     struct curl_slist* headers = NULL;
-    headers = api_auth_headers(headers);
+    api_result_e auth_result = api_auth_headers(&headers);
+    if (auth_result != API_OK) {
+        curl_mime_free(mime);
+        curl_slist_free_all(headers);
+        curl_easy_cleanup(curl);
+        if (result)
+            *result = auth_result;
+
+        return -1;
+    }
 
     // Configure curl for PUT with multipart body and perform request
     curl_easy_setopt(curl, CURLOPT_URL, url);
@@ -453,7 +488,17 @@ extern torrent_dto_t* api_upload_torrent(const torrent_upload_t* upload,
     // Set up headers and response buffer
     struct curl_slist* headers = NULL;
     headers = curl_slist_append(headers, "Accept: application/json");
-    headers = api_auth_headers(headers);
+    api_result_e auth_result = api_auth_headers(&headers);
+    if (auth_result != API_OK) {
+        curl_mime_free(mime);
+        curl_slist_free_all(headers);
+        curl_easy_cleanup(curl);
+        g_free(json_str);
+        if (result)
+            *result = auth_result;
+
+        return NULL;
+    }
 
     response_buf_t response = response_buf_init();
 

--- a/src/api/torrents.h
+++ b/src/api/torrents.h
@@ -63,6 +63,7 @@ char* build_update_json(const torrent_update_t* update);
  *
  * @param upload The torrent_upload_t to serialize
  * @return char* Allocated JSON string, or NULL on error. Caller must free with
+ * g_free().
  */
 char* build_upload_json(const torrent_upload_t* upload);
 
@@ -110,7 +111,7 @@ extern int api_get_torrent_file(int64_t torrent_id,
 
 /**
  * @brief Replace the .torrent file for an existing torrent.
- * PUT /torrent/{id}/file
+ * PUT /torrents/{id}/file
  *
  * @param torrent_id The torrent ID whose file to replace
  * @param file_path Local path to the replacement .torrent file

--- a/src/api/torrents.h
+++ b/src/api/torrents.h
@@ -19,11 +19,6 @@ typedef struct {
     char* updated_at;
 } torrent_dto_t;
 
-typedef struct {
-    char* name;
-    char* description;
-} torrent_update_t;
-
 /**
  * @brief Input for updating torrent metadata. Only non-NULL fields are sent.
  */

--- a/src/api/torrents.h
+++ b/src/api/torrents.h
@@ -19,6 +19,11 @@ typedef struct {
     char* updated_at;
 } torrent_dto_t;
 
+typedef struct {
+    char* name;
+    char* description;
+} torrent_update_t;
+
 /**
  * @brief Parse a JSON string into a torrent_dto_t. Internal function for
  * parsing API responses.
@@ -28,6 +33,16 @@ typedef struct {
  * with torrent_dto_free().
  */
 torrent_dto_t* parse_torrent_json(const char* json_str);
+
+/**
+ * @brief Serialize a torrent_update_t into a JSON string. Internal function for
+ * sending API requests.
+ *
+ * @param update The torrent_update_t to serialize
+ * @return char* Allocated JSON string, or NULL on error. Caller must free with
+ * g_free().
+ */
+char* build_update_json(const torrent_update_t* update);
 
 /**
  * @brief Free a torrent_dto_t and its internal string fields.
@@ -45,5 +60,30 @@ extern void torrent_dto_free(torrent_dto_t* dto);
  * torrent_dto_free().
  */
 extern torrent_dto_t* api_get_torrent(int64_t torrent_id, api_result_e* result);
+
+/**
+ * @brief Update torrent metadata with non-NULL fields. PUT /torrents/{id}
+ *
+ * @param torrent_id The torrent ID to update
+ * @param update The fields to update (name and/or description, can be NULL)
+ * @param result Pointer to store the API result code
+ * @return torrent_dto_t* The updated torrent, or NULL on error. Caller must
+ * free with torrent_dto_free().
+ */
+extern torrent_dto_t* api_update_torrent(int64_t torrent_id,
+                                         const torrent_update_t* update,
+                                         api_result_e* result);
+
+/**
+ * @brief Download a .torrent file to disk. GET /torrents/{id}/file
+ *
+ * @param torrent_id The torrent ID whose file to download
+ * @param output_path The file path to save the downloaded .torrent to
+ * @param result Pointer to store the API result code
+ * @return int 0 on success, non-zero on error
+ */
+extern int api_get_torrent_file(int64_t torrent_id,
+                                const char* output_path,
+                                api_result_e* result);
 
 #endif  // API_TORRENTS_H_

--- a/src/api/torrents.h
+++ b/src/api/torrents.h
@@ -19,10 +19,23 @@ typedef struct {
     char* updated_at;
 } torrent_dto_t;
 
+/**
+ * @brief Input for updating torrent metadata. Only non-NULL fields are sent.
+ */
 typedef struct {
-    char* name;
-    char* description;
+    const char* name;
+    const char* description;
 } torrent_update_t;
+
+/**
+ * @brief Input for uploading a new torrent. name and file_path are required,
+ * description is optional.
+ */
+typedef struct {
+    const char* name;
+    const char* description;
+    const char* file_path;
+} torrent_upload_t;
 
 /**
  * @brief Parse a JSON string into a torrent_dto_t. Internal function for
@@ -43,6 +56,15 @@ torrent_dto_t* parse_torrent_json(const char* json_str);
  * g_free().
  */
 char* build_update_json(const torrent_update_t* update);
+
+/**
+ * @brief Serialize a torrent_upload_t into a JSON string. Internal function for
+ * sending API requests.
+ *
+ * @param upload The torrent_upload_t to serialize
+ * @return char* Allocated JSON string, or NULL on error. Caller must free with
+ */
+char* build_upload_json(const torrent_upload_t* upload);
 
 /**
  * @brief Free a torrent_dto_t and its internal string fields.
@@ -85,5 +107,29 @@ extern torrent_dto_t* api_update_torrent(int64_t torrent_id,
 extern int api_get_torrent_file(int64_t torrent_id,
                                 const char* output_path,
                                 api_result_e* result);
+
+/**
+ * @brief Replace the .torrent file for an existing torrent.
+ * PUT /torrent/{id}/file
+ *
+ * @param torrent_id The torrent ID whose file to replace
+ * @param file_path Local path to the replacement .torrent file
+ * @param result Pointer to store the API result code
+ * @return int 0 on success, non-zero on error
+ */
+extern int api_update_torrent_file(int64_t torrent_id,
+                                   const char* file_path,
+                                   api_result_e* result);
+
+/**
+ * @brief Upload a new torrent with metadata and .torrent file. POST /torrents
+ *
+ * @param upload The upload parameters (name, file_path, optional description)
+ * @param result Pointer to store the API result code
+ * @return torrent_dto_t* The created torrent, or NULL on error. Caller must
+ * free with torrent_dto_free().
+ */
+extern torrent_dto_t* api_upload_torrent(const torrent_upload_t* upload,
+                                         api_result_e* result);
 
 #endif  // API_TORRENTS_H_

--- a/src/api/torrents.h
+++ b/src/api/torrents.h
@@ -19,6 +19,11 @@ typedef struct {
     char* updated_at;
 } torrent_dto_t;
 
+typedef struct {
+    char* name;
+    char* description;
+} torrent_update_t;
+
 /**
  * @brief Input for updating torrent metadata. Only non-NULL fields are sent.
  */

--- a/src/api/torrents.h
+++ b/src/api/torrents.h
@@ -1,0 +1,49 @@
+#ifndef API_TORRENTS_H_
+#define API_TORRENTS_H_
+
+#include <stdint.h>
+#include "api/internal.h"
+
+/**
+ * @brief Represents a torrent (repository) returned by the API. Maps to
+ * TorrentDto in the backend.
+ */
+typedef struct {
+    int64_t id;
+    char* name;
+    char* description;
+    int64_t file_size;
+    int32_t uploader_id;
+    char* uploader_username;
+    char* created_at;
+    char* updated_at;
+} torrent_dto_t;
+
+/**
+ * @brief Parse a JSON string into a torrent_dto_t. Internal function for
+ * parsing API responses.
+ *
+ * @param json_str The JSON string to parse
+ * @return torrent_dto_t* The parsed torrent, or NULL on error. Caller must free
+ * with torrent_dto_free().
+ */
+torrent_dto_t* parse_torrent_json(const char* json_str);
+
+/**
+ * @brief Free a torrent_dto_t and its internal string fields.
+ *
+ * @param dto The torrent_dto_t to free (can be NULL)
+ */
+extern void torrent_dto_free(torrent_dto_t* dto);
+
+/**
+ * @brief Get torrent metadata by ID. GET /torrents/{id}
+ *
+ * @param torrent_id The torrent ID
+ * @param result Pointer to store the API result code
+ * @return torrent_dto_t* The torrent, or NULL on error. Caller must free with
+ * torrent_dto_free().
+ */
+extern torrent_dto_t* api_get_torrent(int64_t torrent_id, api_result_e* result);
+
+#endif  // API_TORRENTS_H_

--- a/test/api_test.c
+++ b/test/api_test.c
@@ -81,6 +81,7 @@ static void shouldPass_whenNetworkAPIUrlNotSet() {
 }
 
 static void shouldPass_whenParsingWithAllFieldsPresent(void) {
+    // GIVEN: A JSON string with all fields present
     const char* json =
         "{"
         "  \"id\": 67,"
@@ -93,8 +94,10 @@ static void shouldPass_whenParsingWithAllFieldsPresent(void) {
         "  \"updatedAt\": \"2019-08-24T14:15:22Z\""
         "}";
 
+    // WHEN: Parse the JSON into a torrent_dto_t
     torrent_dto_t* dto = parse_torrent_json(json);
 
+    // THEN: All fields should be parsed correctly
     TEST_ASSERT_NOT_NULL(dto);
     TEST_ASSERT_EQUAL_INT64(67, dto->id);
     TEST_ASSERT_EQUAL_STRING("awesome-project", dto->name);
@@ -109,6 +112,7 @@ static void shouldPass_whenParsingWithAllFieldsPresent(void) {
 }
 
 static void shouldPass_whenParsingWithNullableFields(void) {
+    // GIVEN: A JSON string with nullable fields set to null
     const char* json =
         "{"
         "  \"id\": 68,"
@@ -119,8 +123,10 @@ static void shouldPass_whenParsingWithNullableFields(void) {
         "  \"updatedAt\": \"2019-08-24T14:15:22Z\""
         "}";
 
+    // WHEN: Parse the JSON into a torrent_dto_t
     torrent_dto_t* dto = parse_torrent_json(json);
 
+    // THEN: nullable fields should be NULL, others parsed correctly
     TEST_ASSERT_NOT_NULL(dto);
     TEST_ASSERT_EQUAL_INT64(68, dto->id);
     TEST_ASSERT_NULL(dto->name);
@@ -130,11 +136,87 @@ static void shouldPass_whenParsingWithNullableFields(void) {
 }
 
 static void shouldPass_whenParsingInvalidJson(void) {
-    TEST_ASSERT_NULL(parse_torrent_json("not valid json {{{"));
+    // GIVEN: An invalid JSON string
+    const char* json = "not valid json {{{";
+
+    // WHEN: Parse the JSON into a torrent_dto_t
+    torrent_dto_t* dto = parse_torrent_json(json);
+
+    // THEN: Should return NULL
+    TEST_ASSERT_NULL(dto);
+}
+static void shouldPass_whenAllFieldsNull(void) {
+    // GIVEN: A torrent_update_t with both fields NULL
+    torrent_update_t update = {.name = NULL, .description = NULL};
+
+    // WHEN: Build JSON string from the update struct
+    char* json = build_update_json(&update);
+
+    // THEN: Should return an empty JSON object
+    TEST_ASSERT_NOT_NULL(json);
+    TEST_ASSERT_EQUAL_STRING("{}", json);
+
+    g_free(json);
+}
+
+static void shouldPass_whenOnlyNameIsSet(void) {
+    // GIVEN: A torrent_update_t with only name set
+    torrent_update_t update = {.name = "My Torrent", .description = NULL};
+
+    // WHEN: Build JSON string from the update struct
+    char* json = build_update_json(&update);
+
+    // THEN: Should include only the name field
+    TEST_ASSERT_NOT_NULL(json);
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"name\""));
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"My Torrent\""));
+    TEST_ASSERT_NULL(strstr(json, "\"description\""));
+
+    g_free(json);
+}
+
+static void shouldPass_whenOnlyDescriptionIsSet(void) {
+    // GIVEN: A torrent_update_t with only description set
+    torrent_update_t update = {.name = NULL, .description = "A description"};
+
+    // WHEN: Build JSON string from the update struct
+    char* json = build_update_json(&update);
+
+    // THEN: Should include only the description field
+    TEST_ASSERT_NOT_NULL(json);
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"description\""));
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"A description\""));
+    TEST_ASSERT_NULL(strstr(json, "\"name\""));
+
+    g_free(json);
+}
+
+static void shouldPass_whenAllFieldsAreSet(void) {
+    // GIVEN: A torrent_update_t with both fields set
+    torrent_update_t update = {.name = "My Torrent",
+                               .description = "A description"};
+
+    // WHEN: Build JSON string from the update struct
+    char* json = build_update_json(&update);
+
+    // THEN: Should include both fields
+    TEST_ASSERT_NOT_NULL(json);
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"name\""));
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"My Torrent\""));
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"description\""));
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"A description\""));
+
+    g_free(json);
 }
 
 static void shouldPass_whenFreeingNullDto(void) {
-    torrent_dto_free(NULL);
+    // GIVEN: A NULL torrent_dto_t pointer
+    torrent_dto_t* dto = NULL;
+
+    // WHEN: Call torrent_dto_free with NULL
+    torrent_dto_free(dto);
+
+    // THEN: Shouldn't crash
     TEST_PASS();
 }
 
@@ -152,6 +234,14 @@ int main() {
     RUN_TEST(shouldPass_whenParsingWithNullableFields);
 
     RUN_TEST(shouldPass_whenParsingInvalidJson);
+
+    RUN_TEST(shouldPass_whenAllFieldsNull);
+
+    RUN_TEST(shouldPass_whenOnlyNameIsSet);
+
+    RUN_TEST(shouldPass_whenOnlyDescriptionIsSet);
+
+    RUN_TEST(shouldPass_whenAllFieldsAreSet);
 
     RUN_TEST(shouldPass_whenFreeingNullDto);
 

--- a/test/api_test.c
+++ b/test/api_test.c
@@ -145,7 +145,8 @@ static void shouldPass_whenParsingInvalidJson(void) {
     // THEN: Should return NULL
     TEST_ASSERT_NULL(dto);
 }
-static void shouldPass_whenAllFieldsNull(void) {
+
+static void shouldPass_whenUpdateWithAllFieldsNull(void) {
     // GIVEN: A torrent_update_t with both fields NULL
     torrent_update_t update = {.name = NULL, .description = NULL};
 
@@ -159,7 +160,7 @@ static void shouldPass_whenAllFieldsNull(void) {
     g_free(json);
 }
 
-static void shouldPass_whenOnlyNameIsSet(void) {
+static void shouldPass_whenUpdateWithOnlyNameIsSet(void) {
     // GIVEN: A torrent_update_t with only name set
     torrent_update_t update = {.name = "My Torrent", .description = NULL};
 
@@ -175,7 +176,7 @@ static void shouldPass_whenOnlyNameIsSet(void) {
     g_free(json);
 }
 
-static void shouldPass_whenOnlyDescriptionIsSet(void) {
+static void shouldPass_whenUpdateWithOnlyDescriptionIsSet(void) {
     // GIVEN: A torrent_update_t with only description set
     torrent_update_t update = {.name = NULL, .description = "A description"};
 
@@ -191,7 +192,7 @@ static void shouldPass_whenOnlyDescriptionIsSet(void) {
     g_free(json);
 }
 
-static void shouldPass_whenAllFieldsAreSet(void) {
+static void shouldPass_whenUpdateWithAllFieldsAreSet(void) {
     // GIVEN: A torrent_update_t with both fields set
     torrent_update_t update = {.name = "My Torrent",
                                .description = "A description"};
@@ -205,6 +206,92 @@ static void shouldPass_whenAllFieldsAreSet(void) {
     TEST_ASSERT_NOT_NULL(strstr(json, "\"My Torrent\""));
     TEST_ASSERT_NOT_NULL(strstr(json, "\"description\""));
     TEST_ASSERT_NOT_NULL(strstr(json, "\"A description\""));
+
+    g_free(json);
+}
+
+static void shouldPass_whenUploadWithAllFieldsNull(void) {
+    // GIVEN: A torrent_upload_t with all fields NULL
+    torrent_upload_t upload = {
+        .name = NULL, .description = NULL, .file_path = NULL};
+
+    // WHEN: Build JSON string from the upload struct
+    char* json = build_upload_json(&upload);
+
+    // THEN: Should return a JSON string
+    TEST_ASSERT_NOT_NULL(json);
+
+    g_free(json);
+}
+
+static void shouldPass_whenUploadWithOnlyNameIsSet(void) {
+    // GIVEN: A torrent_upload_t with only name set
+    torrent_upload_t upload = {
+        .name = "My Torrent", .description = NULL, .file_path = NULL};
+
+    // WHEN: Build JSON string from the upload struct
+    char* json = build_upload_json(&upload);
+
+    // THEN: Should include only the name field
+    TEST_ASSERT_NOT_NULL(json);
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"name\""));
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"My Torrent\""));
+    TEST_ASSERT_NULL(strstr(json, "\"description\""));
+
+    g_free(json);
+}
+
+static void shouldPass_whenUploadWithOnlyDescriptionIsSet(void) {
+    // GIVEN: A torrent_upload_t with only description set
+    torrent_upload_t upload = {
+        .name = NULL, .description = "A description", .file_path = NULL};
+
+    // WHEN: Build JSON string from the upload struct
+    char* json = build_upload_json(&upload);
+
+    // THEN: Should include only the description field
+    TEST_ASSERT_NOT_NULL(json);
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"description\""));
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"A description\""));
+
+    g_free(json);
+}
+
+static void shouldPass_whenUploadWithRequiredFieldsSet(void) {
+    // GIVEN: A torrent_upload_t with required fields set
+    torrent_upload_t upload = {.name = "My Torrent",
+                               .description = NULL,
+                               .file_path = "/tmp/file.torrent"};
+
+    // WHEN: Build JSON string from the upload struct
+    char* json = build_upload_json(&upload);
+
+    // THEN: Should include only the name field
+    TEST_ASSERT_NOT_NULL(json);
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"name\""));
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"My Torrent\""));
+    TEST_ASSERT_NULL(strstr(json, "\"description\""));
+    TEST_ASSERT_NULL(strstr(json, "\"file_path\""));
+
+    g_free(json);
+}
+
+static void shouldPass_whenUploadWithAllFieldsAreSet(void) {
+    // GIVEN: A torrent_upload_t with all fields set
+    torrent_upload_t upload = {.name = "My Torrent",
+                               .description = "A description",
+                               .file_path = "/tmp/file.torrent"};
+
+    // WHEN: Build JSON string from the upload struct
+    char* json = build_upload_json(&upload);
+
+    // THEN: Should include name and description only
+    TEST_ASSERT_NOT_NULL(json);
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"name\""));
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"My Torrent\""));
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"description\""));
+    TEST_ASSERT_NOT_NULL(strstr(json, "\"A description\""));
+    TEST_ASSERT_NULL(strstr(json, "\"file_path\""));
 
     g_free(json);
 }
@@ -235,13 +322,23 @@ int main() {
 
     RUN_TEST(shouldPass_whenParsingInvalidJson);
 
-    RUN_TEST(shouldPass_whenAllFieldsNull);
+    RUN_TEST(shouldPass_whenUpdateWithAllFieldsNull);
 
-    RUN_TEST(shouldPass_whenOnlyNameIsSet);
+    RUN_TEST(shouldPass_whenUpdateWithOnlyNameIsSet);
 
-    RUN_TEST(shouldPass_whenOnlyDescriptionIsSet);
+    RUN_TEST(shouldPass_whenUpdateWithOnlyDescriptionIsSet);
 
-    RUN_TEST(shouldPass_whenAllFieldsAreSet);
+    RUN_TEST(shouldPass_whenUpdateWithAllFieldsAreSet);
+
+    RUN_TEST(shouldPass_whenUploadWithAllFieldsNull);
+
+    RUN_TEST(shouldPass_whenUploadWithOnlyNameIsSet);
+
+    RUN_TEST(shouldPass_whenUploadWithOnlyDescriptionIsSet);
+
+    RUN_TEST(shouldPass_whenUploadWithRequiredFieldsSet);
+
+    RUN_TEST(shouldPass_whenUploadWithAllFieldsAreSet);
 
     RUN_TEST(shouldPass_whenFreeingNullDto);
 

--- a/test/api_test.c
+++ b/test/api_test.c
@@ -309,6 +309,7 @@ static void shouldPass_whenFreeingNullDto(void) {
 
 int main() {
     UNITY_BEGIN();
+    api_init();
 
     setUp();
     RUN_TEST(shouldPass_whenNetworkAPIUrlIsSet);
@@ -342,5 +343,6 @@ int main() {
 
     RUN_TEST(shouldPass_whenFreeingNullDto);
 
+    api_cleanup();
     return UNITY_END();
 }

--- a/test/api_test.c
+++ b/test/api_test.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <unistd.h>
 #include "api/api.h"
+#include "api/torrents.h"
 #include "cmd/cmd.h"
 #include "config/config.h"
 #include "unity/unity.h"
@@ -79,6 +80,64 @@ static void shouldPass_whenNetworkAPIUrlNotSet() {
     TEST_ASSERT_EQUAL(0, err);
 }
 
+static void shouldPass_whenParsingWithAllFieldsPresent(void) {
+    const char* json =
+        "{"
+        "  \"id\": 67,"
+        "  \"name\": \"awesome-project\","
+        "  \"description\": \"An awesome project\","
+        "  \"fileSize\": 1,"
+        "  \"uploaderId\": 2,"
+        "  \"uploaderUsername\": \"johnDoe\","
+        "  \"createdAt\": \"2019-08-24T14:15:22Z\","
+        "  \"updatedAt\": \"2019-08-24T14:15:22Z\""
+        "}";
+
+    torrent_dto_t* dto = parse_torrent_json(json);
+
+    TEST_ASSERT_NOT_NULL(dto);
+    TEST_ASSERT_EQUAL_INT64(67, dto->id);
+    TEST_ASSERT_EQUAL_STRING("awesome-project", dto->name);
+    TEST_ASSERT_EQUAL_STRING("An awesome project", dto->description);
+    TEST_ASSERT_EQUAL_INT64(1, dto->file_size);
+    TEST_ASSERT_EQUAL_INT32(2, dto->uploader_id);
+    TEST_ASSERT_EQUAL_STRING("johnDoe", dto->uploader_username);
+    TEST_ASSERT_EQUAL_STRING("2019-08-24T14:15:22Z", dto->created_at);
+    TEST_ASSERT_EQUAL_STRING("2019-08-24T14:15:22Z", dto->updated_at);
+
+    torrent_dto_free(dto);
+}
+
+static void shouldPass_whenParsingWithNullableFields(void) {
+    const char* json =
+        "{"
+        "  \"id\": 68,"
+        "  \"fileSize\": 1,"
+        "  \"uploaderId\": 3,"
+        "  \"uploaderUsername\": \"janeSmith\","
+        "  \"createdAt\": \"2019-08-24T14:15:22Z\","
+        "  \"updatedAt\": \"2019-08-24T14:15:22Z\""
+        "}";
+
+    torrent_dto_t* dto = parse_torrent_json(json);
+
+    TEST_ASSERT_NOT_NULL(dto);
+    TEST_ASSERT_EQUAL_INT64(68, dto->id);
+    TEST_ASSERT_NULL(dto->name);
+    TEST_ASSERT_NULL(dto->description);
+
+    torrent_dto_free(dto);
+}
+
+static void shouldPass_whenParsingInvalidJson(void) {
+    TEST_ASSERT_NULL(parse_torrent_json("not valid json {{{"));
+}
+
+static void shouldPass_whenFreeingNullDto(void) {
+    torrent_dto_free(NULL);
+    TEST_PASS();
+}
+
 int main() {
     UNITY_BEGIN();
 
@@ -87,6 +146,14 @@ int main() {
     tearDown();
 
     RUN_TEST(shouldPass_whenNetworkAPIUrlNotSet);
+
+    RUN_TEST(shouldPass_whenParsingWithAllFieldsPresent);
+
+    RUN_TEST(shouldPass_whenParsingWithNullableFields);
+
+    RUN_TEST(shouldPass_whenParsingInvalidJson);
+
+    RUN_TEST(shouldPass_whenFreeingNullDto);
 
     return UNITY_END();
 }


### PR DESCRIPTION
**High-level Overview**
Add commands in `src/api/` for the endpoints of managing torrents via the API.

**Description**
Create functions to interface with these API endpoints:
- https://gittor-isu.github.io/GitTor-Web/openapi.html#tag/Torrents/operation/getTorrent
- https://gittor-isu.github.io/GitTor-Web/openapi.html#tag/Torrents/operation/updateTorrent
- https://gittor-isu.github.io/GitTor-Web/openapi.html#tag/Torrents/operation/getTorrentFile
- https://gittor-isu.github.io/GitTor-Web/openapi.html#tag/Torrents/operation/updateTorrentFile
- https://gittor-isu.github.io/GitTor-Web/openapi.html#tag/Torrents/operation/uploadTorrent

**Tests Needed**
If you want to test it with gittor.rent, go for it.

**Acceptance Criteria**
Each of the specified endpoints can be easily called from functions and the data is cleanly handled with structs/arrays/lists, whatever that best looks like in the moment.

**Dev Notes**
I tested it myself against gittor.rent, and there are probably some questionable implementation choices but it should work. Call the `gittor login` command before any other API function to get the access key, which lasts 30 minutes btw.

Really all that changed since initial review was fixing some problems with handling improper authentication.